### PR TITLE
fix(bug): delete button redirect not working properly

### DIFF
--- a/src/app/components/DeleteItem/DeleteItem.tsx
+++ b/src/app/components/DeleteItem/DeleteItem.tsx
@@ -25,7 +25,7 @@ export function DeleteItem(props: DeleteItemProps) {
     });
     if (response) {
       if (response.status === 200) {
-        router.push("/products");
+        router.push(`/${props.table}`);
       }
     }
   }


### PR DESCRIPTION
After clicking the Confirm button to delete a blog, the useer is redirected to the Products page instead of staying on the Blogs page